### PR TITLE
Localhost jako poprawny url w POS

### DIFF
--- a/Model/Fields/PointOfSale/Url.php
+++ b/Model/Fields/PointOfSale/Url.php
@@ -11,6 +11,6 @@ class Url extends Field
 
     protected $maxLength = 255;
 
-    protected $pattern = 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)';
+    protected $pattern = 'https?:\/\/(www\.)?(localhost|([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}))\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)';
 
 }


### PR DESCRIPTION
Walidator sypie błędem jak spróbuje się podać adres bez kropki a localhost jest jednym z adresów, które nagminnie używa się w developmencie.

Głównie byłoby to używane przy return urlach, bo z oczywistych względów taki notification url mógłby zwracać śmieci wam na serwerze.