### PR TITLE
Remove exclude from Psalm

### DIFF
--- a/.dev-tools/psalm.xml
+++ b/.dev-tools/psalm.xml
@@ -12,7 +12,6 @@
         <ignoreFiles>
             <directory name='./' />
             <directory name='../vendor/' />
-            <file name='../src/Model/Objects/Authorization/Token.php' />
         </ignoreFiles>
     </projectFiles>
 


### PR DESCRIPTION
It was crashing (see commits) due to https://github.com/vimeo/psalm/pull/10104.